### PR TITLE
Replace the instatag implementation with the new one

### DIFF
--- a/instatag.admin.inc
+++ b/instatag.admin.inc
@@ -6,10 +6,10 @@
 function instatag_settings() {
   $form = array();
 
-  $form['instatag_snippet_url'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Instatag snippet url'),
-    '#default_value' => variable_get('instatag_snippet_url', ''),
+  $form['instatag_snippet'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Instatag snippet'),
+    '#default_value' => variable_get('instatag_snippet', ''),
     '#required' => TRUE,
   );
 

--- a/instatag.install
+++ b/instatag.install
@@ -9,13 +9,19 @@
  * Implements hook_uninstall().
  */
 function instatag_uninstall() {
-  variable_del('instatag_snippet_url');
+  variable_del('instatag_snippet');
 }
 
 /**
  * Implements hook_install().
  */
 function instatag_install() {
+  $content = '(function(){
+      var script=document.createElement("script");
+      script.src=`https://script.bi-instatag.com?ref=${encodeURIComponent(window.location.href)}`;
+      document.head.appendChild(script);
+      })();';
+  variable_set('instatag_snippet', $content);
   for ($i = 7001; $i < 8000; $i++) {
     $candidate = 'instatag_update_' . $i;
     if (function_exists($candidate)) {
@@ -28,6 +34,11 @@ function instatag_install() {
  * Set instatag snippet url to default content.
  */
 function instatag_update_7001() {
-  $content = '(function(){var script=document.createElement("script");script.src=`https://script.bi-instatag.com?ref=${encodeURIComponent(window.location.href)}`;document.head.appendChild(script);})();';
-  variable_set('instatag_snippet_url', $content);
+  variable_del('instatag_snippet_url');
+  $content = '(function(){
+      var script=document.createElement("script");
+      script.src=`https://script.bi-instatag.com?ref=${encodeURIComponent(window.location.href)}`;
+      document.head.appendChild(script);
+      })();';
+  variable_set('instatag_snippet', $content);
 }

--- a/instatag.install
+++ b/instatag.install
@@ -25,8 +25,9 @@ function instatag_install() {
 }
 
 /**
- * Set instatag snippet url to https://script.bi-instatag.com.
+ * Set instatag snippet url to default content.
  */
 function instatag_update_7001() {
-  variable_set('instatag_snippet_url', 'https://script.bi-instatag.com');
+  $content = '(function(){var script=document.createElement("script");script.src=`https://script.bi-instatag.com?ref=${encodeURIComponent(window.location.href)}`;document.head.appendChild(script);})();';
+  variable_set('instatag_snippet_url', $content);
 }

--- a/instatag.module
+++ b/instatag.module
@@ -40,7 +40,7 @@ function instatag_menu() {
  */
 function instatag_preprocess_html(&$variables) {
   $add_instatag_to_page = TRUE;
-  $url = variable_get('instatag_snippet_url', FALSE);
+  $url = variable_get('instatag_snippet', FALSE);
 
   // If instatag url is not defnied, don't add instatag.
   if (empty($url)) {
@@ -129,11 +129,4 @@ function instatag_published_revision_state($node) {
     return TRUE;
   }
   return FALSE;
-}
-
-/**
- * Implements hook_form_FORM_ID_alter.
- */
-function instatag_form_instatag_settings_alter(&$form, &$form_state, $form_id) {
-  $form['instatag_snippet_url']['#maxlength'] = 512;
 }

--- a/instatag.module
+++ b/instatag.module
@@ -65,7 +65,7 @@ function instatag_preprocess_html(&$variables) {
   if ($add_instatag_to_page === TRUE) {
     $elem = array(
       '#type' => 'markup',
-      '#markup' => sprintf('<script src="%s"></script>', $url),
+      '#markup' => sprintf('<script>%s</script>', $url),
       '#weight' => 1000,
     );
     $variables['instatag'] = $elem;
@@ -129,4 +129,11 @@ function instatag_published_revision_state($node) {
     return TRUE;
   }
   return FALSE;
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter.
+ */
+function instatag_form_instatag_settings_alter(&$form, &$form_state, $form_id) {
+  $form['instatag_snippet_url']['#maxlength'] = 512;
 }


### PR DESCRIPTION
This change is being done for https://jira.factorial.io/browse/WSD-956

New instatag implementation as per above mentioned jira should be:
```html
<script>
    (function(){
      var script=document.createElement("script");
      script.src=`https://script.bi-instatag.com?ref=${encodeURIComponent(window.location.href)}`;
      document.head.appendChild(script);
      })();
</script>
```
The current implementation is replaced with new one mentioned above, please review and verify the changes done.


---

EDIT: Removed `type="text/javascript"` from the script tag.