### PR TITLE
Rerun 7001 as some installations might have already ran it.

### DIFF
--- a/instatag.install
+++ b/instatag.install
@@ -42,3 +42,10 @@ function instatag_update_7001() {
       })();';
   variable_set('instatag_snippet', $content);
 }
+
+/**
+ * Rerun update hook.
+ */
+function instatag_update_7002() {
+  instatag_update_7001();
+}


### PR DESCRIPTION
The last committed changes did change the update hook 7001 instead of creating a new one. This might be a problem for some installations where the previous update hook was already executed.